### PR TITLE
feat: setPathValue returns the object in which the value was set. Closes #6

### DIFF
--- a/index.js
+++ b/index.js
@@ -293,6 +293,7 @@ function getPathValue(obj, path) {
 function setPathValue(obj, path, val) {
   var parsed = parsePath(path);
   internalSetPathValue(obj, val, parsed);
+  return obj;
 }
 
 module.exports = {

--- a/test/index.js
+++ b/test/index.js
@@ -208,4 +208,10 @@ describe('setPathValue', function () {
     assert(obj.hello[1] === 2);
     assert(obj.hello[2] === 3);
   });
+
+  it('returns the object in which the value was set', function () {
+    var obj = { hello: [ 1, 2, 4 ] };
+    var valueReturned = pathval.setPathValue(obj, 'hello[2]', 3);
+    assert(obj === valueReturned);
+  });
 });


### PR DESCRIPTION
This aims to solve #6.
I'm just returning the whole object in which we've set the value.
I also added tests for that.