### PR TITLE
Add readme note about security concerns

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,3 +145,19 @@ pathval.setPathValue(obj, 'earth.country', 'USA');
 
 obj.earth.country; // 'USA'
 ```
+
+
+### Warning!
+
+`pathval` as a module is able to set arbitrary values to arbitrary objects. If you're using this for production purposes, you should only use values that you can trust, or you must sanitise them properly. Refer to the following code for an example of how this may cause security issues if you do not properly sanitize strings:
+
+```js
+var pathval = require("pathval")
+const maliciousUnsanitisedInput = '__proto__.toString'
+
+
+const myUser = {}
+pathval.setPathValue(myUser, maliciousUnsanitisedInput, '1')
+
+Object.prototype.toString === '1' // oh no!
+```


### PR DESCRIPTION
We had a security vulnerability report about this repository, saying that users can accidentally assign arbitrary values to root objects, such as `Object.prototype`. Here's the full message:

> I'm reaching out from the npm security team as a vulnerability has been reported in a package that you maintain, pathval. We have validated the claims in our own environment.
> 
> Please let us know if you plan to address this vulnerability so we can communicate this to the reporter. If we do not hear back we will issue a security advisory after 45 days.
> 
> Sometimes we lack context about the usage of packages which may result in non-issues being reported as security vulnerabilities. If that is the case for this report please explain the reason and we will disregard it.
> 
> Proof-of-concept:
> ```js
> var _ = require('pathval');
> var malicious_path = 'proto.baz';
> 
> var foo = {};
> var bar = {};
> 
> console.log("bar.baz (Before) : " + bar.baz);
> _.setPathValue(foo, malicious_path, 'It works!');
> console.log("bar.baz (After) : " + bar.baz);
> ```

Our code works as intended, it is designed to set arbitrary values to arbitrary paths. There are myriad ways that unsanitised input could effect the host environment, not limited to just `__proto__`; for example `setPathValue(Object, 'prototype.baz', 'It works!')` would have the same effect. I relayed this to the npm security team, who suggested we update the readme on this package to reflect this issue:

> Thank you for the clarification. We will disregard the vulnerability report. Would it be possible to add a note in the README clarifying that the function allows adding properties to prototypes? Just to ensure that users of pathval aren't caught by surprise.
> 
> Thank you in advance!


This PR just adds a readme note to that effect. 