### PR TITLE
Drop `NODE_AUTH_TOKEN` from publish script, update versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,10 +8,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 25
       - run: npm ci
       - run: npm run build --if-present
       - run: npm test
@@ -22,10 +22,10 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22.x
+          node-version: 25
           registry-url: "https://registry.npmjs.org"
           cache: "npm"
       - run: npm ci
@@ -34,5 +34,3 @@ jobs:
         env:
           TAG_NAME: ${{ github.ref_name }}
       - run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.npm_secret }}


### PR DESCRIPTION
This now uses OIDC for publishing